### PR TITLE
Fixed problem with object property names.

### DIFF
--- a/lib/declaration.ts
+++ b/lib/declaration.ts
@@ -526,12 +526,8 @@ export default class DeclarationTranspiler extends base.TranspilerBase {
         }
       } break;
       case ts.SyntaxKind.StringLiteral: {
-        this.emit('String');
-        this.enterCodeComment();
         let sLit = <ts.LiteralExpression>node;
-        let text = JSON.stringify(sLit.text);
-        this.emit(text);
-        this.exitCodeComment();
+        this.emit(sLit.text);
       } break;
       case ts.SyntaxKind.CallSignature: {
         let fn = <ts.SignatureDeclaration>node;

--- a/test/declaration_test.ts
+++ b/test/declaration_test.ts
@@ -381,7 +381,7 @@ abstract class X {
 }`);
   });
   it('supports interface properties', () => {
-    expectTranslate('interface X { x: string; y; }').to.equal(`@anonymous
+    expectTranslate(`interface X { 'x': string; y; }`).to.equal(`@anonymous
 @JS()
 abstract class X {
   external String get x;


### PR DESCRIPTION
The problem was that { 'x': number } was being converted to { num
String/*x*/ }

The problem arose because TypeScript now has two different types of
string literals. LiteralType is now used for types and StringLiteral is
the type of an actual string literal.